### PR TITLE
Fix installer SHA256 checksums in WinDateFrom manifest

### DIFF
--- a/manifests/g/GiulioSorrentino/WinDateFrom/6.0.1.1/GiulioSorrentino.WinDateFrom.installer.yaml
+++ b/manifests/g/GiulioSorrentino/WinDateFrom/6.0.1.1/GiulioSorrentino.WinDateFrom.installer.yaml
@@ -11,10 +11,10 @@ ProductCode: '{A2941143-09E9-45AD-8017-0DB4298D90D4}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/GiulianoSpaghetti/WinDateFrom.avalonia/releases/download/6.0.1/WinDateFrom.Avalonia-6.0.1.1-amd64.msi
-  InstallerSha256: 8D5F0B8E4F76836975FCABE1EFA5A58DF0B692666FACE2F359F8D8C54046AE04
+  InstallerSha256: e1ff6e48c20eb549b6d9bc19023bb67ceb848364ec046f1afe464e7784360b1a
 - Architecture: arm64
   InstallerUrl: https://github.com/GiulianoSpaghetti/WinDateFrom.avalonia/releases/download/6.0.1/WinDateFrom.Avalonia-6.0.1.1-arm64.msi
-  InstallerSha256: 7B83F2330CBBB6DDB520B779DB64C9298D7174C56E5614333604F72EDE3B47A6
+  InstallerSha256: a13eaf1df13ef7554704aa1ce0e62952095e277a941550dd7163f4eb6d45ea73
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-04-21


### PR DESCRIPTION
Updated installer SHA256 checksums for x64 and arm64 architectures.

<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [ ] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.